### PR TITLE
Enable use of Bearer token

### DIFF
--- a/uw_sws/dao.py
+++ b/uw_sws/dao.py
@@ -21,6 +21,14 @@ class SWS_DAO(DAO):
     def service_mock_paths(self):
         return [abspath(os.path.join(dirname(__file__), "resources"))]
 
+    def _custom_headers(self, method, url, headers, body):
+        headers = {}
+        if hasattr(settings, 'RESTCLIENTS_SWS_OAUTH_BEARER'):
+            bearer_key = settings.RESTCLIENTS_SWS_OAUTH_BEARER
+
+            headers["Authorization"] = "Bearer %s" % bearer_key
+        return headers
+
     def _edit_mock_response(self, method, url, headers, body, response):
         if "GET" == method:
             self._update_get(url, response)


### PR DESCRIPTION
Enables the use of a token for SWS instead of cert and key, for access to non-restricted resources, as in http://wiki.cac.washington.edu/pages/viewpage.action?pageId=64919400

This was implemented in the sws client before the reorganization: https://github.com/uw-it-aca/uw-restclients/pull/137