### PR TITLE
Enable use of Bearer token

### DIFF
--- a/uw_sws/dao.py
+++ b/uw_sws/dao.py
@@ -21,6 +21,14 @@ class SWS_DAO(DAO):
     def service_mock_paths(self):
         return [abspath(os.path.join(dirname(__file__), "resources"))]
 
+    def _custom_headers(self, method, url, headers, body):
+        headers = {}
+        if hasattr(settings, 'RESTCLIENTS_SWS_OAUTH_BEARER'):
+            bearer_key = settings.RESTCLIENTS_SWS_OAUTH_BEARER
+
+            headers["Authorization"] = "Bearer %s" % bearer_key
+        return headers
+
     def _edit_mock_response(self, method, url, headers, body, response):
         if "GET" == method:
             self._update_get(url, response)

--- a/uw_sws/dao.py
+++ b/uw_sws/dao.py
@@ -22,13 +22,13 @@ class SWS_DAO(DAO):
         return [abspath(os.path.join(dirname(__file__), "resources"))]
 
     def _custom_headers(self, method, url, headers, body):
-        headers = {}
+        custom_headers = {}
 
         bearer_key = self.get_service_setting('OAUTH_BEARER')
         if bearer_key is not None:
-            headers["Authorization"] = "Bearer %s" % bearer_key
+            custom_headers["Authorization"] = "Bearer %s" % bearer_key
 
-        return headers
+        return custom_headers
 
     def _edit_mock_response(self, method, url, headers, body, response):
         if "GET" == method:

--- a/uw_sws/dao.py
+++ b/uw_sws/dao.py
@@ -23,10 +23,11 @@ class SWS_DAO(DAO):
 
     def _custom_headers(self, method, url, headers, body):
         headers = {}
-        if hasattr(settings, 'RESTCLIENTS_SWS_OAUTH_BEARER'):
-            bearer_key = settings.RESTCLIENTS_SWS_OAUTH_BEARER
 
+        bearer_key = self.get_service_setting('OAUTH_BEARER')
+        if bearer_key is not None:
             headers["Authorization"] = "Bearer %s" % bearer_key
+
         return headers
 
     def _edit_mock_response(self, method, url, headers, body, response):

--- a/uw_sws/tests/test_dao.py
+++ b/uw_sws/tests/test_dao.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+from uw_sws.dao import SWS_DAO
+from commonconf import override_settings
+
+
+class SWSTestDao(TestCase):
+
+    def test_custom_headers(self):
+        self.assertEquals(SWS_DAO()._custom_headers('GET', '/', {}, None), {})
+        with override_settings(RESTCLIENTS_SWS_OAUTH_BEARER='token'):
+            self.assertEquals(
+                SWS_DAO()._custom_headers('GET', '/', {}, None),
+                {'Authorization': 'Bearer token'}
+            )


### PR DESCRIPTION
Enables the use of a token for SWS instead of cert and key, for access to non-restricted resources, as in http://wiki.cac.washington.edu/pages/viewpage.action?pageId=64919400

This was implemented in the sws client before the reorganization: https://github.com/uw-it-aca/uw-restclients/pull/137