### PR TITLE
check LastDayOfClasses when GradeSubmissionDeadline is null

### DIFF
--- a/uw_sws/models.py
+++ b/uw_sws/models.py
@@ -350,7 +350,7 @@ class Term(models.Model):
 
     def is_past(self, comparison_datetime):
         return (self.get_end_of_the_term() is None and
-                comparison_datetime > self.get_eod_last_instruction() or
+                comparison_datetime > self.get_eod_last_final_exam() or
                 comparison_datetime > self.get_end_of_the_term())
 
     def is_future(self, comparison_datetime):

--- a/uw_sws/models.py
+++ b/uw_sws/models.py
@@ -281,8 +281,7 @@ class Term(models.Model):
 
     def is_grading_period_past(self):
         comparison_datetime = datetime.now()
-        return (self.grade_submission_deadline is None and
-                comparison_datetime > self.get_eod_last_instruction() or
+        return (self.grade_submission_deadline is None or
                 comparison_datetime > self.grade_submission_deadline)
 
     def get_week_of_term(self):

--- a/uw_sws/models.py
+++ b/uw_sws/models.py
@@ -280,9 +280,8 @@ class Term(models.Model):
                 open_date <= datetime.now() <= self.grade_submission_deadline)
 
     def is_grading_period_past(self):
-        comparison_datetime = datetime.now()
         return (self.grade_submission_deadline is None or
-                comparison_datetime > self.grade_submission_deadline)
+                datetime.now() > self.grade_submission_deadline)
 
     def get_week_of_term(self):
         return self.get_week_of_term_for_date(datetime.now())

--- a/uw_sws/models.py
+++ b/uw_sws/models.py
@@ -280,8 +280,10 @@ class Term(models.Model):
                 open_date <= datetime.now() <= self.grade_submission_deadline)
 
     def is_grading_period_past(self):
-        return (self.grade_submission_deadline is None or
-                datetime.now() > self.grade_submission_deadline)
+        comparison_datetime = datetime.now()
+        return (self.grade_submission_deadline is None and
+                comparison_datetime > self.get_eod_last_instruction() or
+                comparison_datetime > self.grade_submission_deadline)
 
     def get_week_of_term(self):
         return self.get_week_of_term_for_date(datetime.now())
@@ -349,7 +351,8 @@ class Term(models.Model):
                 comparison_datetime < self.get_end_of_the_term())
 
     def is_past(self, comparison_datetime):
-        return (self.get_end_of_the_term() is None or
+        return (self.get_end_of_the_term() is None and
+                comparison_datetime > self.get_eod_last_instruction() or
                 comparison_datetime > self.get_end_of_the_term())
 
     def is_future(self, comparison_datetime):

--- a/uw_sws/models.py
+++ b/uw_sws/models.py
@@ -277,11 +277,11 @@ class Term(models.Model):
 
         return (open_date is not None and
                 self.grade_submission_deadline is not None and
-                open_date <= datetime.now() <= self.grade_submission_deadline))
+                open_date <= datetime.now() <= self.grade_submission_deadline)
 
     def is_grading_period_past(self):
         return (self.grade_submission_deadline is None or
-                datetime.now() > self.grade_submission_deadline))
+                datetime.now() > self.grade_submission_deadline)
 
     def get_week_of_term(self):
         return self.get_week_of_term_for_date(datetime.now())

--- a/uw_sws/tests/test_term.py
+++ b/uw_sws/tests/test_term.py
@@ -413,9 +413,16 @@ class SWSTestTerm(TestCase):
         self.assertEquals(term.registration_services_start, None)
 
         # Loading a term with null Grading Periods
-        term = get_term_by_year_and_quarter(2008, 'autumn')
-        self.assertEquals(term.grading_period_open, None)
-        self.assertEquals(term.grading_period_close, None)
+        term = get_term_by_year_and_quarter(1998, 'spring')
+        self.assertIsNone(term.grading_period_open)
+        self.assertIsNone(term.grading_period_close)
+        self.assertIsNone(term.grade_submission_deadline)
+        self.assertIsNone(term.aterm_grading_period_open)
+        self.assertFalse(term.is_grading_period_open())
+        self.assertTrue(term.is_grading_period_past())
+        self.assertTrue(term.is_past(datetime.now()))
+        self.assertFalse(term.is_current(datetime.now()))
+        self.assertFalse(term.is_future(datetime.now()))
 
     def test_week_of_term(self):
         now = datetime.now()


### PR DESCRIPTION
I just checked that GradeSubmissionDeadline for any future quarter won't be null. 
So it is OK without this additional check although I would like to have it