### PR TITLE
uses isoformat (work on all browsers) for converting date to string (…

### DIFF
--- a/uw_sws/tests/test_adviser.py
+++ b/uw_sws/tests/test_adviser.py
@@ -29,7 +29,7 @@ class AdviserTest(TestCase):
              'is_honors_program': True,
              'regid': '24A20F50AE3511D68CBC0004AC494FFE',
              'uwnetid': 'uwhonors',
-             'timestamp': '2020-03-24 13:07:14'})
+             'timestamp': '2020-03-24T13:07:14'})
         self.assertIsNotNone(str(advisers))
 
     def test_error_case(self):

--- a/uw_sws/tests/test_notice.py
+++ b/uw_sws/tests/test_notice.py
@@ -13,9 +13,10 @@ from datetime import timedelta
 
 
 def date_to_dtime(adate):
-    return str(SWS_TIMEZONE.localize(
-        datetime(year=adate.year, month=adate.month,
-                 day=adate.day)).astimezone(pytz.utc))
+    return SWS_TIMEZONE.localize(
+        datetime(
+            year=adate.year, month=adate.month, day=adate.day)
+        ).astimezone(pytz.utc).isoformat()
 
 
 @fdao_pws_override

--- a/uw_sws/tests/test_registrations.py
+++ b/uw_sws/tests/test_registrations.py
@@ -92,7 +92,7 @@ class SWSTestRegistrations(TestCase):
              'is_withdrew': False,
              'meta_data': 'RegistrationSourceLocation=SDB;',
              'repeat_course': False,
-             'repository_timestamp': '2016-01-05 14:45:15',
+             'repository_timestamp': '2016-01-05T14:45:15',
              'request_date': '2015-11-18',
              'request_status': 'DROPPED FROM CLASS',
              'start_date': None})

--- a/uw_sws/util.py
+++ b/uw_sws/util.py
@@ -19,7 +19,8 @@ def str_to_date(s):
 
 
 def date_to_str(dt):
-    return str(dt) if dt is not None else None
+    # datetime.datetime.isoformat
+    return dt.isoformat() if dt is not None else None
 
 
 def abbr_week_month_day_str(adatetime):


### PR DESCRIPTION
…#179)

Use isoformat (work on all browsers) for converting date or datetime to string