### PR TITLE
fixing issue with prev/next term during quarter breaks

### DIFF
--- a/uw_sws/term.py
+++ b/uw_sws/term.py
@@ -36,23 +36,39 @@ def get_current_term():
     # classes.  That's too late to be useful, so if we're after the last
     # day of grade submission window, use the next term resource.
     if term.is_grading_period_past():
-        return get_next_term()
+        return get_next_term_sws()
     return term
 
 
 def get_next_term():
     """
     Returns a uw_sws.models.Term object,
-    for the next term.
+    for the term after the current term.
     """
-    url = "{}/next.json".format(term_res_url_prefix)
-    return Term(data=get_resource(url))
+    return get_term_after(get_current_term())
 
 
 def get_previous_term():
     """
     Returns a uw_sws.models.Term object,
-    for the previous term.
+    for the term before the current term.
+    """
+    return get_term_before(get_current_term())
+
+
+def get_next_term_sws():
+    """
+    Returns a uw_sws.models.Term object,
+    for the term in next.json.
+    """
+    url = "{}/next.json".format(term_res_url_prefix)
+    return Term(data=get_resource(url))
+
+
+def get_previous_term_sws():
+    """
+    Returns a uw_sws.models.Term object,
+    for the term in previous.json.
     """
     url = "{}/previous.json".format(term_res_url_prefix)
     return Term(data=get_resource(url))

--- a/uw_sws/tests/test_term.py
+++ b/uw_sws/tests/test_term.py
@@ -11,8 +11,14 @@ from restclients_core.exceptions import DataFailureException
 from uw_sws.models import Term
 from uw_sws.term import (
     get_term_by_year_and_quarter, get_term_before, get_term_after,
-    get_current_term, get_next_term, get_previous_term, get_term_by_date,
+    get_current_term, get_next_term_sws, get_previous_term_sws, get_next_term,
+    get_previous_term, get_term_by_date,
     get_specific_term, get_next_autumn_term, get_next_non_summer_term)
+from mock import patch
+
+
+def mock_is_grading_period_past(self):
+    return True
 
 
 @fdao_sws_override
@@ -175,9 +181,15 @@ class SWSTestTerm(TestCase):
 
         self.assertFalse(term.is_summer_quarter())
 
+    @patch.object(Term, 'is_grading_period_past', mock_is_grading_period_past)
+    def test_current_term_past_grading(self):
+        term = get_current_term()
+        self.assertEqual(term.quarter, 'summer')
+        self.assertEqual(term.year, 2013)
+
     # Expected values will have to change when the json files are updated
-    def test_previous_quarter(self):
-        term = get_previous_term()
+    def test_previous_quarter_sws(self):
+        term = get_previous_term_sws()
 
         expected_quarter = "winter"
         expected_year = 2013
@@ -246,9 +258,19 @@ class SWSTestTerm(TestCase):
                           "Grading period is past")
         self.assertEquals(term.term_label(), "2013,winter", "Term label")
 
-    # Expected values will have to change when the json files are updated
-    def test_next_quarter(self):
+    def test_next_term(self):
         term = get_next_term()
+        self.assertEquals(term.year, 2013)
+        self.assertEquals(term.quarter, 'summer')
+
+    def test_previous_term(self):
+        term = get_previous_term()
+        self.assertEquals(term.year, 2013)
+        self.assertEquals(term.quarter, 'winter')
+
+    # Expected values will have to change when the json files are updated
+    def test_next_quarter_sws(self):
+        term = get_next_term_sws()
         self.assertTrue(term.is_summer_quarter())
         expected_quarter = "summer"
         expected_year = 2013


### PR DESCRIPTION
There is an issue where, during quarter breaks, `get_current_term` will get what is officially the **next** term, but this logic was not applied to the previous/next term methods, so they display the official next/previous term which conflicts with what our `get_current_term` returns.